### PR TITLE
configure vercel deployment workflows

### DIFF
--- a/.github/workflows/vercel-merge.yml
+++ b/.github/workflows/vercel-merge.yml
@@ -1,0 +1,37 @@
+name: 'Deploy to vercel on merge'
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  build_and_deploy:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Install pnpm'
+        uses: 'pnpm/action-setup@v4'
+        with:
+          version: '10'
+          run_install: false
+
+      - name: 'Install Node.js'
+        uses: 'actions/setup-node@v4'
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: 'Install dependencies'
+        run: 'pnpm install'
+
+      - name: 'Build project'
+        run: 'pnpm build'
+
+      - name: 'Deploy to Vercel (prod)'
+        uses: 'amondnet/vercel-action@v25'
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'

--- a/.github/workflows/vercel-pull-request.yml
+++ b/.github/workflows/vercel-pull-request.yml
@@ -36,6 +36,8 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          alias-domains: |
+            pr-{{PR_NUMBER}}.randomizer.aoe2.studio
 
       - name: 'preview-url'
         run: |

--- a/.github/workflows/vercel-pull-request.yml
+++ b/.github/workflows/vercel-pull-request.yml
@@ -1,0 +1,42 @@
+name: 'Create vercel preview URL on pull request'
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  build_and_deploy:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Install pnpm'
+        uses: 'pnpm/action-setup@v4'
+        with:
+          version: '10'
+          run_install: false
+
+      - name: 'Install Node.js'
+        uses: 'actions/setup-node@v4'
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: 'Install dependencies'
+        run: 'pnpm install'
+
+      - name: 'Build project'
+        run: 'pnpm build'
+
+      - name: 'Deploy to Vercel'
+        id: 'vercel-deploy'
+        uses: 'amondnet/vercel-action@v25'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: 'preview-url'
+        run: |
+          echo ${{ steps.vercel-deploy.outputs.preview-url }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "public": false,
+  "github": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
This PR sets up (hopefully) manual Vercel deployment since they want to charge me $20/month just to use automated github deployment from an organization. NO THANKS

We have two workflows: one for merges to `main` (`vercel-merge`) and the other for pull requests to `main` (`vercel-pull-request`). Both workflows build the project locally and then use `@amondnet/vercel-actions@v25` to deploy it appropriately. The pull request workflow should automatically comment with a link to a pr-specific preview deployment.