### PR TITLE
prevent infinite loop when only 1 civ is unplayed

### DIFF
--- a/src/actors/app.ts
+++ b/src/actors/app.ts
@@ -74,6 +74,7 @@ export const appMachine = setup({
         const unplayedCivs = context.enabled.filter(
           (civ) => !context.played.includes(civ),
         )
+        if (unplayedCivs.length === 1) return unplayedCivs[0]
 
         // prevent next civ from being the same as the current civ
         let nextCiv


### PR DESCRIPTION
This PR prevents an infinite loop when only 1 civ is unplayed. The loop could occur if the only unplayed civ was played then unplayed, then randomize was clicked again. Since randomize prevents the next `currentCiv` from being the same as the previous `currentCiv`, it would get into a state where those values could never be different.